### PR TITLE
Seperate key and value when iterating on the hash.

### DIFF
--- a/lib/prophet/forecaster.rb
+++ b/lib/prophet/forecaster.rb
@@ -659,7 +659,7 @@ module Prophet
         # Nothing to fit.
         @params = stan_init
         @params["sigma_obs"] = 1e-9
-        @params.each do |par|
+        @params.each do |par, _|
           @params[par] = Numo::NArray.asarray(@params[par])
         end
       elsif @mcmc_samples > 0


### PR DESCRIPTION
Unlike in the [Python code](https://github.com/facebook/prophet/blob/0d260699e4776c449703a957f08eca8013461a47/python/fbprophet/forecaster.py#L1161) which only iterates over dictornary keys if only one variable is present for the iterator, Ruby iterates over an array of `[key, value]`, which causes `@params[par]` to be evaluated as `nil`.

PR #3 contains a test case which executes these lines.